### PR TITLE
Added switch to use Zabbix API >7.4

### DIFF
--- a/automap.py
+++ b/automap.py
@@ -157,9 +157,9 @@ def main(
         zabbix_scheme=zabbix_scheme.value,
         zabbix_folder=zabbix_folder,
         map_name=zabbix_map_name,
-        map_layout=map_layout.value, 
+        map_layout=map_layout.value,
         host_group_name=zabbix_host_group_name,
-        zabbix_api= zabbix_api,
+        zabbix_api=zabbix_api,
     )
 
     logger.debug(f"{automaper.graph.graph.vs.attribute_names()}")

--- a/automap.py
+++ b/automap.py
@@ -105,6 +105,10 @@ def main(
                 help="zabbix folder (where the api_jsonrpc.php file resides, normally /zabbix or /)",
             ),
         ] = "/zabbix",
+        zabbix_api: Annotated[
+            str,
+            typer.Option("--zabbix_api", "-a", help="zabbix api new or old"),
+        ] = "new",
         map_layout: Annotated[
             type_layout,
             typer.Option("--map_layout", "-L", help="Map layout to use"),
@@ -153,8 +157,9 @@ def main(
         zabbix_scheme=zabbix_scheme.value,
         zabbix_folder=zabbix_folder,
         map_name=zabbix_map_name,
-        map_layout=map_layout.value,
+        map_layout=map_layout.value, 
         host_group_name=zabbix_host_group_name,
+        zabbix_api= zabbix_api,
     )
 
     logger.debug(f"{automaper.graph.graph.vs.attribute_names()}")

--- a/automapLib/automaper.py
+++ b/automapLib/automaper.py
@@ -28,6 +28,7 @@ class Automaper:
             zabbix_port,
             zabbix_scheme,
             zabbix_folder,
+            zabbix_api,
             host_group_name,
             map_name,
             map_layout,
@@ -43,6 +44,7 @@ class Automaper:
             zabbix_port=zabbix_port,
             zabbix_scheme=zabbix_scheme,
             zabbix_folder=zabbix_folder,
+            zabbix_api=zabbix_api,
         )
         self.zabbix.create_api()
         self.host_group_name = host_group_name
@@ -100,16 +102,16 @@ class Automaper:
         logging.debug(f"list host : {list_host}")
         for edge in self.graph.get_edges():
             logging.debug(f"{edge}")
-            list_link.append(
-                {
-                    "linkid": edge["name"],
+            link = {
                     "label": edge["label"],
                     "selementid1": edge["host1"],
                     "selementid2": edge["host2"],
                     "color": edge["color"],
                     "drawtype": edge["draw_type"],
                 }
-            )
+            if self.zabbix.zabbix_api == "old":
+                link["linkid"] = edge["name"]
+            list_link.append(link)
         logging.debug(f"list link : {list_link}")
 
         self.zabbix.update_map(

--- a/automapLib/zabbix.py
+++ b/automapLib/zabbix.py
@@ -14,6 +14,7 @@ class Zabbix:
     zabbix_port: int = 80
     zabbix_scheme: str = "http"
     zabbix_folder: str = "/zabbix"
+    zabbix_api: str = "new"
     api: ZabbixAPI = None
     logger: logging = logging.getLogger("Zabbix")
 
@@ -23,7 +24,7 @@ class Zabbix:
 
     def create_api(self):
         self.logger.info(f"create zabbix api")
-        self.api = ZabbixAPI(url=self.zabbix_url, token=self.zabbix_token)
+        self.api = ZabbixAPI(url=self.zabbix_url, token=self.zabbix_token, skip_version_check=True)
 
     def get_hosts_in_host_group_name(self, host_group_name) -> list[Host]:
         groupid = self.get_host_group_from_name(host_group_name)


### PR DESCRIPTION
The API is not supporting to get the "linkid" set manually. I've added a switch to turn that off.

New switch is --zabbix_api new/old
default value is "new"